### PR TITLE
docs: add public roadmap content

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,37 @@
+---
+name: Bug
+about: Report a product bug
+title: "Short summary of the bug"
+labels: "type: bug"
+assignees: ""
+---
+
+## Summary
+
+One clear sentence describing the problem.
+
+## Area
+
+Examples: Telegram bot, Mini app, Web app, Flights, Hotels, Alerts, Billing, Profile.
+
+## Steps to reproduce
+
+1. 
+2. 
+3. 
+
+## Expected behavior
+
+What should happen.
+
+## Actual behavior
+
+What happens instead.
+
+## Screenshots or recordings
+
+Add visuals if they help explain the problem.
+
+## Additional context
+
+Anything else that helps reproduce or understand the issue.

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,31 @@
+---
+name: Feature
+about: Request a new user-facing feature
+title: "Short summary of the feature request"
+labels: "type: feature"
+assignees: ""
+---
+
+## Problem
+
+What user problem should this feature solve?
+
+## Requested solution
+
+Describe the feature from a user perspective.
+
+## Area
+
+Examples: Telegram bot, Mini app, Web app, Flights, Hotels, Alerts, Billing, Profile.
+
+## Why this matters
+
+Explain the impact on planning, booking, tracking, or account management.
+
+## Examples or references
+
+Add screenshots, competitor examples, or flow sketches if useful.
+
+## Additional context
+
+Anything else that would help define the request.

--- a/.github/ISSUE_TEMPLATE/improvement.md
+++ b/.github/ISSUE_TEMPLATE/improvement.md
@@ -1,0 +1,31 @@
+---
+name: Improvement
+about: Suggest an improvement to an existing flow
+title: "Short summary of the improvement"
+labels: "type: improvement"
+assignees: ""
+---
+
+## Current flow
+
+Describe how the product works today.
+
+## Problem
+
+What makes the current experience confusing, slow, or incomplete?
+
+## Suggested improvement
+
+Describe the change from a user perspective.
+
+## Area
+
+Examples: Telegram bot, Mini app, Web app, Flights, Hotels, Alerts, Billing, Profile.
+
+## Expected outcome
+
+What becomes better after this improvement?
+
+## Screenshots or references
+
+Add visuals or examples if helpful.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,76 @@
+# TripRadar Public Roadmap
+
+This repository is the public roadmap for TripRadar.
+
+Use it to:
+- report product bugs,
+- request new features,
+- suggest improvements to existing flows,
+- upvote and comment on issues that matter to you.
+
+TripRadar is a travel planning product built around:
+- Telegram-based trip planning and notifications,
+- flight and hotel search,
+- price alerts and scheduled checks,
+- trip history and saved trips,
+- web and mini app account experience.
+
+## Before opening an issue
+
+1. Search existing issues first.
+2. If you find a matching issue, add context there instead of creating a duplicate.
+3. Add screenshots, steps, and expected behavior whenever possible.
+
+## Issue types
+
+- `Bug`: something is broken or behaves incorrectly.
+- `Feature`: a new user-facing capability.
+- `Improvement`: an existing flow works, but should work better.
+
+## Good issue examples
+
+Good public roadmap issues are specific and user-facing:
+- "Telegram bot sends duplicate flight price alerts"
+- "Mini app should support editing an active price alert"
+- "Profile page should make scheduled requests easier to manage"
+- "Trip history needs better filters for saved searches"
+
+Avoid internal-only issues such as:
+- infrastructure refactors,
+- private operational tooling,
+- internal observability changes,
+- implementation details without user impact.
+
+## Product areas
+
+When relevant, mention which area is affected:
+- Telegram bot
+- Mini app
+- Web app
+- Flights
+- Hotels
+- Alerts and tracking
+- Authentication and profile
+- Billing and pricing
+- Trip history and saved trips
+
+## What to include
+
+For bugs:
+- where it happens,
+- what you expected,
+- what actually happened,
+- how to reproduce it,
+- screenshots or recordings if available.
+
+For features and improvements:
+- the problem you are trying to solve,
+- the current workaround, if any,
+- the expected outcome,
+- screenshots, mockups, or examples if available.
+
+## Triage policy
+
+We review issues, group similar requests, and use reactions and comments as one of the input signals for prioritization.
+
+Opening an issue does not mean immediate delivery, and issue order should not be treated as a delivery timeline.


### PR DESCRIPTION
## Что сделано
Заполнен публичный roadmap-репозиторий под текущий продукт TripRadar.

## Причина изменений
Репозиторий содержал шаблонный контент от другого проекта и не отражал реальные пользовательские сценарии TripRadar.

## Основные изменения
- заменен README на TripRadar-specific public roadmap overview
- обновлены issue templates для bug, feature и improvement
- убраны чужие и внутренние ссылки из шаблонов
- оставлены только user-facing формулировки и продуктовые области

## Проверка
1. Открыть README в репозитории
2. Открыть формы создания bug/feature/improvement issue
3. Убедиться, что тексты относятся к TripRadar, а не к SerpApi

## Примечания
Labels 	ype: bug, 	ype: feature, 	ype: improvement пока не созданы в самом GitHub-репозитории. Шаблоны уже готовы к их использованию, но labels нужно добавить отдельно.